### PR TITLE
Bump versions for parquet, parquet-format, and arrow

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 libc = ">=0.2.90,<1"
 errno = "0.2"
-clap = { version = "=3.0.0-beta.2", features = ["color"] }
+clap = { version = ">=3.0.0-beta.2,<4", features = ["color"] }
 anyhow = "1"
 thiserror = "1"
 serde = { version = "1", features = ["derive"] }
@@ -42,11 +42,11 @@ rusoto_dynamodb = { version = "0.46", default-features = false, optional = true 
 maplit = { version = "1", optional = true }
 
 # High-level writer
-parquet-format = "~2.6.1"
+parquet-format = "~4.0.0"
 
-arrow  = { version = "3" }
-# datafusion = { version = "4", optional = true }
-parquet = { version = "3" }
+arrow  = { version = "8" }
+datafusion = { version = "4", optional = true }
+parquet = { version = "8" }
 cfg-if = "1"
 async-trait = "0.1"
 # NOTE: disable rust-dataframe integration since it currently doesn't have a
@@ -55,7 +55,7 @@ async-trait = "0.1"
 
 [features]
 rust-dataframe-ext = []
-# datafusion-ext = ["datafusion"]
+datafusion-ext = ["datafusion"]
 # azure = ["azure_core", "azure_storage", "reqwest"]
 azure = []
 s3 = ["rusoto_core/native-tls", "rusoto_credential", "rusoto_s3/native-tls", "rusoto_sts/native-tls", "rusoto_dynamodb/native-tls", "maplit"]

--- a/rust/src/delta_arrow.rs
+++ b/rust/src/delta_arrow.rs
@@ -2,7 +2,7 @@
 
 use crate::schema;
 use arrow::datatypes::{
-    DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema, SchemaRef, TimeUnit, DateUnit,
+    DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema, SchemaRef, TimeUnit,
 };
 use arrow::error::ArrowError;
 use lazy_static::lazy_static;
@@ -91,7 +91,7 @@ impl TryFrom<&schema::SchemaDataType> for ArrowDataType {
                     "date" => {
                         // A calendar date, represented as a year-month-day triple without a
                         // timezone.
-                        Ok(ArrowDataType::Date32(DateUnit::Day))
+                        Ok(ArrowDataType::Date32)
                     }
                     "timestamp" => {
                         // Issue: https://github.com/delta-io/delta/issues/643

--- a/rust/src/writer.rs
+++ b/rust/src/writer.rs
@@ -169,7 +169,7 @@ impl ParquetBuffer {
         self.cursor.data()
     }
 
-    fn close(&mut self) -> Result<(), DeltaTableError> {
+    fn close(&mut self) -> Result<parquet_format::FileMetaData, DeltaTableError> {
         self.writer
             .close()
             .map_err(|source| DeltaTableError::ParquetError { source })


### PR DESCRIPTION
# Description
This PR bumps versions for parquet, parquet-format, arrow, datafusion, and clap in order to match dependencies and reverts some changes that were made to downgrade versions for parquet and arrow.